### PR TITLE
Fix the name of the Docker hub organization

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: Tox environment to run the tests on
 runs:
   using: docker
-  image: docker://fedora-python/fedora-python-tox
+  image: docker://fedorapython/fedora-python-tox
   entrypoint: tox
   args:
     - '-e${{ inputs.tox_env }}'


### PR DESCRIPTION
Unfortunately, Docker Hub does not allow to have dashes in the name of an organization.