### PR TITLE
Document repeating the env names in .tox and .github/workflows/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Tox sanity test](https://github.com/fedora-python/tox-github-action/workflows/Tox%20sanity%20test/badge.svg)
+![Run Tox tests](https://github.com/fedora-python/tox-github-action/workflows/Run%20Tox%20tests/badge.svg)
+![Run tests with code in this repository](https://github.com/fedora-python/tox-github-action/workflows/Run%20tests%20with%20code%20in%20this%20repository/badge.svg)
 
 # Tox Github Action
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ Add the action to your workflow file, e.g. `.github/workflows/main.yml`,
 after checking out your code.
 
 You can use the `matrix` strategy to run with multiple Tox environments.
-
 For an example, see [this project's workflow](.github/workflows/main.yml).
+Unfortunately, you need to repeat all the environment names
+from your Tox configuration.
+(As far as we know, this is required in order to have individual environments
+show up as separate runs on GitHub. Discuss this limitation in [issue 8].)
 
+
+[issue 8]: https://github.com/fedora-python/tox-github-action/issues/8
 
 ## License
 


### PR DESCRIPTION
Documents: https://github.com/fedora-python/tox-github-action/issues/8

I've also added an update to the README badges; I can split if this is controversial.