### PR TITLE
Pin to Fedora 34 and add changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ groups or DNF options.
 
 [issue 8]: https://github.com/fedora-python/tox-github-action/issues/8
 
+## Changelog
+
+Until version v0.4, this action always used the latest [fedora-python-tox](https://hub.docker.com/repository/docker/fedorapython/fedora-python-tox)
+image. Since version 34.0, the first number in the version (also sometimes
+referred to as the "major version") represents the release of Fedora used in the image.
+
+### v34.0
+
+* First version pinned explicitly to Fedora 34.
+
 ## License
 
 The code, content and configuration in this repository is given away unter the

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ groups or DNF options.
 
 ## Changelog
 
-Until version v0.4, this action always used the latest [fedora-python-tox](https://hub.docker.com/repository/docker/fedorapython/fedora-python-tox)
+Until version 0.4, this action always used the latest [fedora-python-tox](https://hub.docker.com/repository/docker/fedorapython/fedora-python-tox)
 image. Since version 34.0, the first number in the version (also sometimes
 referred to as the "major version") represents the release of Fedora used in the image.
 

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
     description: Space separated packages to install via dnf install (can contain options)
 runs:
   using: docker
-  image: docker://fedorapython/fedora-python-tox
+  image: docker://fedorapython/fedora-python-tox:f34
   env:
     TOXENV: ${{ inputs.tox_env }}
     DNF_INSTALL: ${{ inputs.dnf_install }}


### PR DESCRIPTION
We have to tag/release v34.0 after this is merged. Then, I'm gonna prepare fedora-python-tox for F35 and then I'll repeat this PR.