### PR TITLE
Update to Fedora 41 and Python 3.13 as the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Until version 0.4, this action always used the latest [fedora-python-tox](https:
 image. Since version 34.0, the first number in the version (also sometimes
 referred to as the "major version") represents the release of Fedora used in the image.
 
+### v41.0
+
+* Uses Fedora 41 as the base container image.
+* Python 2.7 is no longer available.
+* PyPy 3.11 is now available
+* Python 3.13 is now the default tox environment if none is configured.
+
 ### v40.0
 
 * Uses Fedora 40 as the base container image.

--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,7 @@ description: Runs tests with Tox
 inputs:
   tox_env:
     required: true
-    default: 'py312'
+    default: 'py313'
     description: Tox environment to run the tests on
   dnf_install:
     required: false
@@ -16,7 +16,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://fedorapython/fedora-python-tox:f40
+  image: docker://fedorapython/fedora-python-tox:f41
   env:
     TOXENV: ${{ inputs.tox_env }}
     DNF_INSTALL: ${{ inputs.dnf_install }}


### PR DESCRIPTION
Depends-on: https://github.com/fedora-python/fedora-python-tox/pull/83